### PR TITLE
added cors-rack gem to allow posts from cross origins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS),
 # making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 gem 'active_model_serializers'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.2)
@@ -252,6 +254,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
+require 'rack/cors'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -39,5 +40,12 @@ module BikeSafetyApi
 
     config.rswag_host = ENV['RSWAG_HOST'] || "localhost:4000"
     config.rswag_url_prefix = ENV['RSWAG_URL_PREFIX'] || "http://"
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :update, :delete, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
Gives cbus-biking-LOC-api clients access to POST, UPDATE, DELETE, and OPTIONS HTTP requests from cross origins.